### PR TITLE
Add optional emojione support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "illuminate/html": "~5.0",
         "pusher/pusher-php-server": "dev-master"
     },
+    "suggest": {
+        "emojione/emojione": "Will allow emoji support within confer"
+    },
     "autoload": {
         "psr-4": {
           "DJB\\Confer\\": "src/"

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -6,3 +6,8 @@ function confer_make_list($items, $oxford_comma = false)
     if (count($items) == 1) return $list;
     return $oxford_comma ? substr_replace($list, ', and', strrpos($list, ','), strlen(',')) : substr_replace($list, ' and', strrpos($list, ','), strlen(','));
 }
+
+function confer_convert_emoji_to_shortcodes($text)
+{
+	return \Emojione\Emojione::toShort($text);
+}

--- a/src/Http/Controllers/MessageController.php
+++ b/src/Http/Controllers/MessageController.php
@@ -36,7 +36,7 @@ class MessageController extends Controller {
 	public function store(Conversation $conversation, Request $request)
 	{
 		$message = Message::create([
-			'body' => $request->input('body'),
+			'body' => config('confer.enable_emoji') ? confer_convert_emoji_to_shortcodes($request->input('body')) : $request->input('body'),
 			'conversation_id' => $conversation->id,
 			'sender_id' => $this->user->id,
 			'type' => 'user_message'

--- a/src/assets/js/confer.js
+++ b/src/assets/js/confer.js
@@ -270,6 +270,8 @@
 		message.slideDown(100);
 		setTimeout(function() {
 			list.scrollTop(list.prop("scrollHeight"));
+			var body = message.find('.confer-message-body');
+			if (body.length && self.options.use_emoji) body.html(emojione.shortnameToImage(body.text()));
 		}, 150);
 
 	}

--- a/src/assets/js/confer.js
+++ b/src/assets/js/confer.js
@@ -25,6 +25,7 @@
 		messages_container : $('a#messages_open_icon').siblings('ul.dropdown-menu').children('li').first(),
 		connection_retries : 3,
 		verbose : false,
+		use_emoji: true,
 		use_sounds : true,
 		grammar_enforcer : true
 
@@ -981,6 +982,23 @@
 		self.updateTimestampSchedule = setInterval(function() {
 			self.updateTimestamps();
 		}, 60000);
+
+		if (self.options.use_emoji)
+		{
+			self.initialiseEmoji();
+		}
+
+	}
+
+	Confer.prototype.initialiseEmoji = function ()
+	{
+
+		var self = this;
+
+		self.overlay_content.find('.confer-message-body').each(function(index, value) {
+			var text = $(this).text();
+			$(this).html(emojione.shortnameToImage(text));
+		});
 
 	}
 

--- a/src/config/confer.php
+++ b/src/config/confer.php
@@ -5,5 +5,6 @@ return [
 	'loader' => '/vendor/confer/img/puff.svg',
 	'avatar_dir' => '/img/avatars/',
 	'allow_global' => true,
+	'enable_emoji' => false,
 	'grammar_enforcer' => true
 ];

--- a/src/views/js.blade.php
+++ b/src/views/js.blade.php
@@ -30,6 +30,7 @@ String.prototype.capitalize = function() {
 		token : "{{ csrf_token() }}",
 		loader : "{{ config('confer.loader') }}",
         requested_conversations : {{ Session::has('confer_requested_conversations') ? json_encode(Session::get('confer_requested_conversations')) : '[]' }},
+        use_emoji : "{{ config('confer.enable_emoji') }}",
 		grammar_enforcer : "{{ config('confer.grammar_enforcer') }}"
 	};
 	var confer = new window.Confer($('div.confer-overlay'), $('ul.confer-open-conversations-list'), {{ Auth::user()->id }}, options);


### PR DESCRIPTION
This pr request enables emoji support; should the user wish to use it they will require to include emojione in their project.

Emoji appears only in conversations themselves, and not in previews.
